### PR TITLE
Changed String to Abstract String. Fixed warning from v.0.4.

### DIFF
--- a/src/ColorBrewer.jl
+++ b/src/ColorBrewer.jl
@@ -33,7 +33,7 @@ colorSchemes = JSON.parsefile(
 #   ArgumentError: If the number of colors in the palette is invalid.
 #
 # Returns: An array of RGBs (from the Colors package).
-function palette(schemeName::String, n::Integer)
+function palette(schemeName::AbstractString, n::Integer)
     if !haskey(colorSchemes, schemeName)
         throw(ArgumentError("Scheme $schemeName is undefined."));
     end #Close if statement validating scheme name.


### PR DESCRIPTION
I don't know if `String` type at ColorBrewer.jl was left on purpose. But for compatibility with Julia v.0.4 I changed to `AbstractString`. After this the warning at import was removed.
